### PR TITLE
Fix `--log-stdout` CLI option renamed to `--debug-stdout` in latest smbd version

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:smbd]
 priority=1
-command=/usr/sbin/smbd --foreground --no-process-group --log-stdout --configfile=/etc/samba/smb.conf
+command=/usr/sbin/smbd --foreground --no-process-group --debug-stdout --configfile=/etc/samba/smb.conf
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Fix for this issue:
```logs
 Usage: smbd [-?bDiFV] [-?|--help] [--usage] [-b|--build-options]
samba_1  |         [-p|--port=STRING] [-P|--profiling-level=PROFILE_LEVEL]
samba_1  |         [-d|--debuglevel=DEBUGLEVEL] [--debug-stdout]
samba_1  |         [-s|--configfile=CONFIGFILE] [--option=name=value]
samba_1  |         [-l|--log-basename=LOGFILEBASE] [--leak-report] [--leak-report-full]
samba_1  |         [-D|--daemon] [-i|--interactive] [-F|--foreground]
samba_1  |         [--no-process-group] [-V|--version]
samba_1  | 2021-12-15 22:56:41,379 INFO exited: smbd (exit status 1; not expected)
samba_1  | 2021-12-15 22:56:43,382 INFO spawned: 'smbd' with pid 18
samba_1  |
samba_1  | Invalid option --log-stdout: unknown option
```

By changing the CLI launch arg from `--log-stdout` to `--debug-stdout`.
See the smdb changelog for more info: https://www.samba.org/samba/history/samba-4.15.0.html